### PR TITLE
Update OneDrive cleaning script

### DIFF
--- a/online/js/scripts.js
+++ b/online/js/scripts.js
@@ -62,7 +62,7 @@ document.addEventListener("DOMContentLoaded", function() {
       'reg delete "HKEY_CLASSES_ROOT\\WOW6432Node\\CLSID\\{018D5C66-4533-4307-9B53-224DE2ED1FE6}" /f',
       'reg delete "HKEY_CLASSES_ROOT\\CLSID\\{018D5C66-4533-4307-9B53-224DE2ED1FE6}" /f',
       "echo -- Removing OneDrive folders",
-      'rd "%UserProfile%\\OneDrive" /Q /S',
+      'rd "%UserProfile%\\OneDrive" /Q',
       'rd "%LocalAppData%\\Microsoft\\OneDrive" /Q /S',
       'rd "%ProgramData%\\Microsoft\\OneDrive" /Q /S',
       'rd "C:\\OneDriveTemp" /Q /S',

--- a/winscript-app/src/js/scripts.js
+++ b/winscript-app/src/js/scripts.js
@@ -62,7 +62,7 @@ document.addEventListener("DOMContentLoaded", function() {
       'reg delete "HKEY_CLASSES_ROOT\\WOW6432Node\\CLSID\\{018D5C66-4533-4307-9B53-224DE2ED1FE6}" /f',
       'reg delete "HKEY_CLASSES_ROOT\\CLSID\\{018D5C66-4533-4307-9B53-224DE2ED1FE6}" /f',
       "echo -- Removing OneDrive folders",
-      'rd "%UserProfile%\\OneDrive" /Q /S',
+      'rd "%UserProfile%\\OneDrive" /Q',
       'rd "%LocalAppData%\\Microsoft\\OneDrive" /Q /S',
       'rd "%ProgramData%\\Microsoft\\OneDrive" /Q /S',
       'rd "C:\\OneDriveTemp" /Q /S',


### PR DESCRIPTION
Unconditional removal is dangerous. OneDrive can stop working for various reasons, and after a long time a lot of files from your desktop or documents can accumulate in this folder. Without the /S switch, this command will only delete the folder when it is empty. We don't want users to delete their files!