### PR TITLE
feat(i18n): auto-detect OS/browser locale on first launch

### DIFF
--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -32,6 +32,7 @@
     "core:window:allow-hide",
     "core:window:allow-show",
     "os:allow-hostname",
+    "os:allow-locale",
     "core:window:allow-set-effects",
     {
       "identifier": "fs:allow-read-text-file",

--- a/app/src/assets/js/main.js
+++ b/app/src/assets/js/main.js
@@ -34,19 +34,10 @@ async function loadConfig() {
   }
 }
 
-const getSupportedLocales = (() => {
-  let cache;
-  return () => {
-    if (cache) return cache;
-    const buttons = document.querySelectorAll(".use-lang-btn");
-    const locales = new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
-    // Only cache if DOM was parsed and buttons actually exist
-    if (locales.size > 0) {
-      cache = locales;
-    }
-    return locales;
-  };
-})();
+function getSupportedLocales() {
+  const buttons = document.querySelectorAll(".use-lang-btn");
+  return new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
+}
 
 async function detectOsLocale() {
   const supported = getSupportedLocales();
@@ -67,25 +58,19 @@ async function detectOsLocale() {
 }
 
 async function loadLocale() {
-  // Saved preference wins — but validate it's still supported.
+  // Saved preference wins — redirect only if still supported and not already in the URL.
   let locale = localStorage.getItem("locale");
   if (locale) {
     const supported = getSupportedLocales();
     if (supported.has(locale)) {
-      if (locale !== "en") {
+      if (locale !== "en" && !window.location.href.includes(locale)) {
         window.location.href = `/${locale}`;
       }
-    } else if (supported.size > 0) {
-      // Known to be unsupported — clear stale preference.
-      localStorage.removeItem("locale");
-    } else if (locale !== "en") {
-      // DOM not yet parsed — trust the saved preference.
-      window.location.href = `/${locale}`;
     }
     return;
   }
 
-  // First launch — try to match OS language.
+  // No saved preference — detect OS language and redirect only when it isn't English.
   locale = await detectOsLocale();
   if (locale && locale !== "en") {
     localStorage.setItem("locale", locale);

--- a/app/src/assets/js/main.js
+++ b/app/src/assets/js/main.js
@@ -48,9 +48,9 @@ const getSupportedLocales = (() => {
   };
 })();
 
-function detectOsLocale() {
+async function detectOsLocale() {
   const supported = getSupportedLocales();
-  const osLang = osLocale(); // e.g. "zh-CN", "de-DE", "fr-FR"
+  const osLang = await osLocale(); // e.g. "zh-CN", "de-DE", "fr-FR"
 
   if (!osLang) return null;
 
@@ -67,17 +67,20 @@ function detectOsLocale() {
 }
 
 async function loadLocale() {
-  // Saved preference wins.
+  // Saved preference wins — but validate it's still supported.
   let locale = localStorage.getItem("locale");
   if (locale) {
-    if (locale !== "en") {
+    if (getSupportedLocales().has(locale) && locale !== "en") {
       window.location.href = `/${locale}`;
+    }
+    if (!getSupportedLocales().has(locale)) {
+      localStorage.removeItem("locale");
     }
     return;
   }
 
   // First launch — try to match OS language.
-  locale = detectOsLocale();
+  locale = await detectOsLocale();
   if (locale && locale !== "en") {
     localStorage.setItem("locale", locale);
     window.location.href = `/${locale}`;

--- a/app/src/assets/js/main.js
+++ b/app/src/assets/js/main.js
@@ -70,11 +70,17 @@ async function loadLocale() {
   // Saved preference wins — but validate it's still supported.
   let locale = localStorage.getItem("locale");
   if (locale) {
-    if (getSupportedLocales().has(locale) && locale !== "en") {
-      window.location.href = `/${locale}`;
-    }
-    if (!getSupportedLocales().has(locale)) {
+    const supported = getSupportedLocales();
+    if (supported.has(locale)) {
+      if (locale !== "en") {
+        window.location.href = `/${locale}`;
+      }
+    } else if (supported.size > 0) {
+      // Known to be unsupported — clear stale preference.
       localStorage.removeItem("locale");
+    } else if (locale !== "en") {
+      // DOM not yet parsed — trust the saved preference.
+      window.location.href = `/${locale}`;
     }
     return;
   }

--- a/app/src/assets/js/main.js
+++ b/app/src/assets/js/main.js
@@ -39,8 +39,12 @@ const getSupportedLocales = (() => {
   return () => {
     if (cache) return cache;
     const buttons = document.querySelectorAll(".use-lang-btn");
-    cache = new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
-    return cache;
+    const locales = new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
+    // Only cache if DOM was parsed and buttons actually exist
+    if (locales.size > 0) {
+      cache = locales;
+    }
+    return locales;
   };
 })();
 

--- a/app/src/assets/js/main.js
+++ b/app/src/assets/js/main.js
@@ -2,7 +2,7 @@ import { writeTextFile, readTextFile, mkdir, remove, exists } from "@tauri-apps/
 import { tempDir, join, dirname } from "@tauri-apps/api/path";
 import { Command } from "@tauri-apps/plugin-shell";
 import { app } from "@tauri-apps/api";
-import { version, locale as osLocale } from "@tauri-apps/plugin-os";
+import { version, locale as getOsLocale } from "@tauri-apps/plugin-os";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { ask, save, open } from "@tauri-apps/plugin-dialog";
 import { check } from "@tauri-apps/plugin-updater";
@@ -41,7 +41,7 @@ function getSupportedLocales() {
 
 async function detectOsLocale() {
   const supported = getSupportedLocales();
-  const osLang = await osLocale(); // e.g. "zh-CN", "de-DE", "fr-FR"
+  const osLang = await getOsLocale(); // e.g. "zh-CN", "de-DE", "fr-FR"
 
   if (!osLang) return null;
 
@@ -71,10 +71,10 @@ async function loadLocale() {
   }
 
   // No saved preference — detect OS language and redirect only when it isn't English.
-  locale = await detectOsLocale();
-  if (locale && locale !== "en") {
-    localStorage.setItem("locale", locale);
-    window.location.href = `/${locale}`;
+  const osLocale = await detectOsLocale();
+  if (osLocale && osLocale !== "en") {
+    localStorage.setItem("locale", osLocale);
+    window.location.href = `/${osLocale}`;
   }
 }
 

--- a/app/src/assets/js/main.js
+++ b/app/src/assets/js/main.js
@@ -2,7 +2,7 @@ import { writeTextFile, readTextFile, mkdir, remove, exists } from "@tauri-apps/
 import { tempDir, join, dirname } from "@tauri-apps/api/path";
 import { Command } from "@tauri-apps/plugin-shell";
 import { app } from "@tauri-apps/api";
-import { version } from "@tauri-apps/plugin-os";
+import { version, locale as osLocale } from "@tauri-apps/plugin-os";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { ask, save, open } from "@tauri-apps/plugin-dialog";
 import { check } from "@tauri-apps/plugin-updater";
@@ -34,12 +34,48 @@ async function loadConfig() {
   }
 }
 
-async function loadLocale() {
-  let locale = localStorage.getItem("locale");
-  if (!locale) return;
-  if (locale === "en") return;
+const getSupportedLocales = (() => {
+  let cache;
+  return () => {
+    if (cache) return cache;
+    const buttons = document.querySelectorAll(".use-lang-btn");
+    cache = new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
+    return cache;
+  };
+})();
 
-  if (!window.location.href.includes(locale)) {
+function detectOsLocale() {
+  const supported = getSupportedLocales();
+  const osLang = osLocale(); // e.g. "zh-CN", "de-DE", "fr-FR"
+
+  if (!osLang) return null;
+
+  // 1) Exact match
+  if (supported.has(osLang)) {
+    return osLang;
+  }
+  // 2) Prefix match: "de-DE" → "de", "fr-FR" → "fr"
+  const prefix = osLang.split("-")[0];
+  if (prefix !== osLang && supported.has(prefix)) {
+    return prefix;
+  }
+  return null;
+}
+
+async function loadLocale() {
+  // Saved preference wins.
+  let locale = localStorage.getItem("locale");
+  if (locale) {
+    if (locale !== "en") {
+      window.location.href = `/${locale}`;
+    }
+    return;
+  }
+
+  // First launch — try to match OS language.
+  locale = detectOsLocale();
+  if (locale && locale !== "en") {
+    localStorage.setItem("locale", locale);
     window.location.href = `/${locale}`;
   }
 }

--- a/website/src/assets/js/main.js
+++ b/website/src/assets/js/main.js
@@ -55,8 +55,11 @@ function loadLocale() {
   // We are on the root path — pick the best locale.
   let locale = localStorage.getItem("locale");
   if (locale) {
-    if (locale !== "en") {
+    if (getSupportedLocales().has(locale) && locale !== "en") {
       window.location.href = `/${locale}`;
+    }
+    if (!getSupportedLocales().has(locale)) {
+      localStorage.removeItem("locale");
     }
     return;
   }

--- a/website/src/assets/js/main.js
+++ b/website/src/assets/js/main.js
@@ -1,18 +1,9 @@
 // ── Locale auto-detection ──────────────────────────────────────────────
 
-const getSupportedLocales = (() => {
-  let cache;
-  return () => {
-    if (cache) return cache;
-    const buttons = document.querySelectorAll(".use-lang-btn");
-    const locales = new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
-    // Only cache if DOM was parsed and buttons actually exist
-    if (locales.size > 0) {
-      cache = locales;
-    }
-    return locales;
-  };
-})();
+function getSupportedLocales() {
+  const buttons = document.querySelectorAll(".use-lang-btn");
+  return new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
+}
 
 function detectBrowserLocale() {
   const supported = getSupportedLocales();
@@ -32,51 +23,20 @@ function detectBrowserLocale() {
   return null;
 }
 
-function getLocaleFromPath() {
-  const segments = window.location.pathname.split("/").filter(Boolean);
-  // "/" → [], "/de/" → ["de"], "/de/index.html" → ["de", "index.html"]
-  const candidate = segments[0];
-  return candidate && candidate !== "index.html" ? candidate : null;
-}
-
 function loadLocale() {
-  // If the URL already specifies a locale, respect it — don't redirect.
-  const pathLocale = getLocaleFromPath();
-  if (pathLocale) {
-    const supported = getSupportedLocales();
-    if (supported.size > 0) {
-      if (supported.has(pathLocale)) {
-        localStorage.setItem("locale", pathLocale);
-        return;
-      }
-      // Unsupported locale in path (e.g. /xyz) — fall back to English.
-      window.location.href = "/";
-      return;
-    }
-    // DOM not yet parsed or no language switcher on this page —
-    // trust the URL path and don't redirect.
-    return;
-  }
-
-  // We are on the root path — pick the best locale.
+  // Saved preference wins — redirect only if still supported and not already in the URL.
   let locale = localStorage.getItem("locale");
   if (locale) {
     const supported = getSupportedLocales();
     if (supported.has(locale)) {
-      if (locale !== "en") {
+      if (locale !== "en" && !window.location.href.includes(locale)) {
         window.location.href = `/${locale}`;
       }
-    } else if (supported.size > 0) {
-      // Known to be unsupported — clear stale preference.
-      localStorage.removeItem("locale");
-    } else if (locale !== "en") {
-      // DOM not yet parsed — trust the saved preference.
-      window.location.href = `/${locale}`;
     }
     return;
   }
 
-  // First visit — try to match browser language.
+  // No saved preference — detect browser language and redirect only when it isn't English.
   locale = detectBrowserLocale();
   if (locale && locale !== "en") {
     localStorage.setItem("locale", locale);

--- a/website/src/assets/js/main.js
+++ b/website/src/assets/js/main.js
@@ -1,3 +1,71 @@
+// ── Locale auto-detection ──────────────────────────────────────────────
+
+const getSupportedLocales = (() => {
+  let cache;
+  return () => {
+    if (cache) return cache;
+    const buttons = document.querySelectorAll(".use-lang-btn");
+    cache = new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
+    return cache;
+  };
+})();
+
+function detectBrowserLocale() {
+  const supported = getSupportedLocales();
+  const browserLocales = navigator.languages || (navigator.language ? [navigator.language] : []);
+
+  for (const raw of browserLocales) {
+    // 1) Exact match: "zh-CN", "de", "fr", …
+    if (supported.has(raw)) {
+      return raw;
+    }
+    // 2) Prefix match: "de-AT" → "de", "fr-CA" → "fr"
+    const prefix = raw.split("-")[0];
+    if (prefix !== raw && supported.has(prefix)) {
+      return prefix;
+    }
+  }
+  return null;
+}
+
+function getLocaleFromPath() {
+  const segments = window.location.pathname.split("/").filter(Boolean);
+  // "/" → [], "/de/" → ["de"], "/de/index.html" → ["de", "index.html"]
+  const candidate = segments[0];
+  return candidate && candidate !== "index.html" ? candidate : null;
+}
+
+function loadLocale() {
+  // If the URL already specifies a locale, respect it — don't redirect.
+  const pathLocale = getLocaleFromPath();
+  if (pathLocale) {
+    if (getSupportedLocales().has(pathLocale)) {
+      localStorage.setItem("locale", pathLocale);
+      return;
+    }
+    // Unsupported locale in path (e.g. /xyz) — fall back to English.
+    window.location.href = "/";
+    return;
+  }
+
+  // We are on the root path — pick the best locale.
+  let locale = localStorage.getItem("locale");
+  if (locale) {
+    if (locale !== "en") {
+      window.location.href = `/${locale}`;
+    }
+    return;
+  }
+
+  // First visit — try to match browser language.
+  locale = detectBrowserLocale();
+  if (locale && locale !== "en") {
+    localStorage.setItem("locale", locale);
+    window.location.href = `/${locale}`;
+  }
+}
+// ────────────────────────────────────────────────────────────────────────
+
 document.querySelectorAll(".fa-solid").forEach((icon) => {
   icon.addEventListener("click", () => {
     const navbar = document.getElementById("sidebar");
@@ -234,8 +302,11 @@ document.querySelectorAll(".localization-entry").forEach((entry) => {
 
   useBtn.addEventListener("click", (e) => {
     e.stopPropagation();
+    localStorage.setItem("locale", locale);
     // Redirect to /[locale]
     // If locale is en, we could go to / but /en is safer/more consistent
     window.location.href = `/${locale}`;
   });
 });
+
+loadLocale();

--- a/website/src/assets/js/main.js
+++ b/website/src/assets/js/main.js
@@ -43,23 +43,35 @@ function loadLocale() {
   // If the URL already specifies a locale, respect it — don't redirect.
   const pathLocale = getLocaleFromPath();
   if (pathLocale) {
-    if (getSupportedLocales().has(pathLocale)) {
-      localStorage.setItem("locale", pathLocale);
+    const supported = getSupportedLocales();
+    if (supported.size > 0) {
+      if (supported.has(pathLocale)) {
+        localStorage.setItem("locale", pathLocale);
+        return;
+      }
+      // Unsupported locale in path (e.g. /xyz) — fall back to English.
+      window.location.href = "/";
       return;
     }
-    // Unsupported locale in path (e.g. /xyz) — fall back to English.
-    window.location.href = "/";
+    // DOM not yet parsed or no language switcher on this page —
+    // trust the URL path and don't redirect.
     return;
   }
 
   // We are on the root path — pick the best locale.
   let locale = localStorage.getItem("locale");
   if (locale) {
-    if (getSupportedLocales().has(locale) && locale !== "en") {
-      window.location.href = `/${locale}`;
-    }
-    if (!getSupportedLocales().has(locale)) {
+    const supported = getSupportedLocales();
+    if (supported.has(locale)) {
+      if (locale !== "en") {
+        window.location.href = `/${locale}`;
+      }
+    } else if (supported.size > 0) {
+      // Known to be unsupported — clear stale preference.
       localStorage.removeItem("locale");
+    } else if (locale !== "en") {
+      // DOM not yet parsed — trust the saved preference.
+      window.location.href = `/${locale}`;
     }
     return;
   }

--- a/website/src/assets/js/main.js
+++ b/website/src/assets/js/main.js
@@ -5,8 +5,12 @@ const getSupportedLocales = (() => {
   return () => {
     if (cache) return cache;
     const buttons = document.querySelectorAll(".use-lang-btn");
-    cache = new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
-    return cache;
+    const locales = new Set(Array.from(buttons).map((btn) => btn.getAttribute("data-locale")));
+    // Only cache if DOM was parsed and buttons actually exist
+    if (locales.size > 0) {
+      cache = locales;
+    }
+    return locales;
   };
 })();
 

--- a/website/src/assets/js/main.js
+++ b/website/src/assets/js/main.js
@@ -9,14 +9,14 @@ function detectBrowserLocale() {
   const supported = getSupportedLocales();
   const browserLocales = navigator.languages || (navigator.language ? [navigator.language] : []);
 
-  for (const raw of browserLocales) {
+  for (const rawLocale of browserLocales) {
     // 1) Exact match: "zh-CN", "de", "fr", …
-    if (supported.has(raw)) {
-      return raw;
+    if (supported.has(rawLocale)) {
+      return rawLocale;
     }
     // 2) Prefix match: "de-AT" → "de", "fr-CA" → "fr"
-    const prefix = raw.split("-")[0];
-    if (prefix !== raw && supported.has(prefix)) {
+    const prefix = rawLocale.split("-")[0];
+    if (prefix !== rawLocale && supported.has(prefix)) {
       return prefix;
     }
   }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Style
- [x] Localization
- [ ] Other

## Description

Automatically detect the user's OS/browser locale on first launch and redirect to the corresponding localized page.

- **Desktop (Tauri)**: reads the OS locale via the `os:allow-locale` plugin
- **Website**: detects browser language preference via `navigator.languages`
- **Matching strategy**: exact match → prefix match (e.g. `de-AT` → `de`)
- **Priority**: saved user preference > URL path > OS/browser locale > English default
- Both `app/` and `website/` versions updated in sync